### PR TITLE
Fix segment alignment in gpacmp4mx for single sink pads usages

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -91,13 +91,14 @@ runs:
       if: inputs.for-test == 'true' && steps.cache-gst.outputs.cache-hit != 'true'
       uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
 
-    - name: Install cargo-c
+    - name: Install build dependencies
       if: inputs.for-test == 'true' && steps.cache-gst.outputs.cache-hit != 'true'
       shell: bash
       run: |
         if [[ ${{ runner.os }} == 'macOS' ]]; then
-          brew install cargo-c
+          brew install cargo-c meson
         else
+          sudo apt-get install -y python3 python3-pip python3-setuptools python3-wheel python3-mesonpy ninja-build
           cargo install cargo-c
         fi
 
@@ -119,18 +120,18 @@ runs:
       shell: bash
       working-directory: ${{ runner.temp }}/gst-plugins-rs
       run: |
-        cargo cbuild -p gst-plugin-fmp4
-        cargo cinstall -p gst-plugin-fmp4 --destdir bin
+        meson setup build -Dauto_features=disabled -Dfmp4=enabled
+        meson compile -C build
 
     - name: Install cmafmux element
       if: inputs.for-test == 'true'
       shell: bash
-      working-directory: ${{ runner.temp }}/gst-plugins-rs
+      working-directory: ${{ runner.temp }}/gst-plugins-rs/build
       run: |
         dst_dir=$HOME/.local/share/gstreamer-1.0/plugins
         mkdir -p $dst_dir
         if [[ ${{ runner.os }} == 'macOS' ]]; then
-          cp bin/usr/local/lib/gstreamer-1.0/libgstfmp4.dylib $dst_dir/
+          cp libgstfmp4.dylib $dst_dir/
         else
-          cp bin/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfmp4.so $dst_dir/
+          cp libgstfmp4.so $dst_dir/
         fi

--- a/include/lib/caps.h
+++ b/include/lib/caps.h
@@ -89,6 +89,21 @@ typedef struct
   GstStaticCaps caption_caps;
 } GstGpacFormatProp;
 
+typedef enum
+{
+  TEMPLATE_VIDEO,
+  TEMPLATE_AUDIO,
+  TEMPLATE_SUBTITLE,
+  TEMPLATE_CAPTION,
+} GstGpacSinkTemplateType;
+
+/*! Get the sink pad template for the given type
+    \param[in] type the type of the sink pad template
+    \return the GstPadTemplate
+*/
+GstPadTemplate*
+gst_gpac_get_sink_template(GstGpacSinkTemplateType type);
+
 /*! Install the sink pad templates for the given element class
     \param[in] klass the element class to install the pad templates
 */

--- a/src/elements/gstgpactf.c
+++ b/src/elements/gstgpactf.c
@@ -318,7 +318,8 @@ gst_gpac_tf_consume(GstAggregator* agg, Bool is_eos)
         // memout is not connected, just send one dummy buffer
         if (is_eos)
           return GST_FLOW_EOS;
-        GST_DEBUG_OBJECT(agg, "Sending dummy buffer, shouldn't happen!");
+        GST_DEBUG_OBJECT(
+          agg, "Sending dummy buffer, possibly connected to fakesink");
         return gst_aggregator_finish_buffer(agg, gst_buffer_new());
 
       case GPAC_FILTER_PP_RET_BUFFER:
@@ -795,6 +796,7 @@ gst_gpac_tf_start(GstAggregator* aggregator)
   }
   GST_DEBUG_OBJECT(element, "GPAC session started");
 
+  // Initialize the segment
   gst_segment_init(&segment, GST_FORMAT_TIME);
   gst_aggregator_update_segment(aggregator, &segment);
   return TRUE;

--- a/src/elements/gstgpactf.c
+++ b/src/elements/gstgpactf.c
@@ -409,7 +409,13 @@ gst_gpac_tf_sink_event(GstAggregator* agg,
       priv->segment = gst_segment_copy(segment);
       priv->flags |= GPAC_PAD_SEGMENT_SET;
       priv->dts_offset_set = FALSE;
-      gst_aggregator_update_segment(agg, gst_segment_copy(segment));
+
+      // Update the segment only if video pad or the only pad
+      gboolean is_video_pad = gst_pad_get_pad_template(GST_PAD(pad)) ==
+                              gst_gpac_get_sink_template(TEMPLATE_VIDEO);
+      gboolean is_only_pad = g_list_length(GST_ELEMENT(agg)->sinkpads) == 1;
+      if (is_video_pad || is_only_pad)
+        gst_aggregator_update_segment(agg, gst_segment_copy(segment));
 
       // Set the global offset
       gpac_memio_set_global_offset(GPAC_SESS_CTX(GPAC_CTX), segment);

--- a/src/elements/gstgpactf.c
+++ b/src/elements/gstgpactf.c
@@ -583,26 +583,10 @@ gst_gpac_tf_aggregate(GstAggregator* agg, gboolean timeout)
 
 // #MARK: Pad Management
 static GstAggregatorPad*
-gst_gpac_tf_create_new_pad(GstAggregator* self,
+gst_gpac_tf_create_new_pad(GstAggregator* element,
                            GstPadTemplate* templ,
-                           const gchar* req_name,
+                           const gchar* pad_name,
                            const GstCaps* caps)
-{
-  return g_object_new(GST_TYPE_GPAC_TF_PAD,
-                      "name",
-                      req_name,
-                      "direction",
-                      templ->direction,
-                      "template",
-                      templ,
-                      NULL);
-}
-
-static GstPad*
-gst_gpac_tf_request_new_pad(GstElement* element,
-                            GstPadTemplate* templ,
-                            const gchar* pad_name,
-                            const GstCaps* caps)
 {
   GstElementClass* klass = GST_ELEMENT_GET_CLASS(element);
   GstGpacTransform* agg = GST_GPAC_TF(element);
@@ -634,9 +618,14 @@ gst_gpac_tf_request_new_pad(GstElement* element,
   GST_DEBUG_OBJECT(agg, "Creating new pad %s", name);
 
   // Create the pad
-  GstGpacTransformPad* pad =
-    (GstGpacTransformPad*)GST_ELEMENT_CLASS(parent_class)
-      ->request_new_pad(element, templ, name, caps);
+  GstGpacTransformPad* pad = g_object_new(GST_TYPE_GPAC_TF_PAD,
+                                          "name",
+                                          name,
+                                          "direction",
+                                          templ->direction,
+                                          "template",
+                                          templ,
+                                          NULL);
   g_free(name);
 
   // Initialize the private data
@@ -646,14 +635,7 @@ gst_gpac_tf_request_new_pad(GstElement* element,
     priv->flags |= GPAC_PAD_CAPS_SET;
   }
 
-  return GST_PAD(pad);
-}
-
-static void
-gst_gpac_tf_release_pad(GstElement* element, GstPad* pad)
-{
-  GST_DEBUG_OBJECT(element, "Releasing pad %s:%s", GST_DEBUG_PAD_NAME(pad));
-  GST_ELEMENT_CLASS(parent_class)->release_pad(element, pad);
+  return GST_AGGREGATOR_PAD(pad);
 }
 
 // #MARK: Lifecycle
@@ -862,9 +844,9 @@ gst_gpac_tf_class_init(GstGpacTransformClass* klass)
   // Set the pad management functions
   gstaggregator_class->create_new_pad =
     GST_DEBUG_FUNCPTR(gst_gpac_tf_create_new_pad);
-  gstelement_class->request_new_pad =
-    GST_DEBUG_FUNCPTR(gst_gpac_tf_request_new_pad);
-  gstelement_class->release_pad = GST_DEBUG_FUNCPTR(gst_gpac_tf_release_pad);
+  // gstelement_class->request_new_pad =
+  // GST_DEBUG_FUNCPTR(gst_gpac_tf_request_new_pad);
+  // gstelement_class->release_pad = GST_DEBUG_FUNCPTR(gst_gpac_tf_release_pad);
 
   // Set the aggregator functions
   gstaggregator_class->sink_event = GST_DEBUG_FUNCPTR(gst_gpac_tf_sink_event);

--- a/src/lib/caps.c
+++ b/src/lib/caps.c
@@ -32,14 +32,13 @@ GstGpacFormatProp gst_gpac_sink_formats = {
   .caption_caps = GST_STATIC_CAPS(CEA708_CAPS),
 };
 
-enum
-{
-  TEMPLATE_VIDEO,
-  TEMPLATE_AUDIO,
-  TEMPLATE_SUBTITLE,
-  TEMPLATE_CAPTION,
-};
 GstPadTemplate* sink_templates[4] = { NULL };
+
+GstPadTemplate*
+gst_gpac_get_sink_template(GstGpacSinkTemplateType type)
+{
+  return sink_templates[type];
+}
 
 void
 gpac_install_sink_pad_templates(GstElementClass* klass)

--- a/src/lib/filters/mp4mx.c
+++ b/src/lib/filters/mp4mx.c
@@ -322,7 +322,7 @@ mp4mx_create_buffer_list(GF_Filter* filter)
     GST_BUFFER_DTS(GET_TYPE(INIT)->buffer) =
       GST_BUFFER_DTS(GET_TYPE(HEADER)->buffer) -
       GST_BUFFER_DURATION(GET_TYPE(HEADER)->buffer);
-    GST_BUFFER_DURATION(GET_TYPE(INIT)->buffer) = GST_CLOCK_TIME_NONE;
+    GST_BUFFER_DURATION(GET_TYPE(INIT)->buffer) = 0;
   }
 
   // Copy the mdat header

--- a/src/lib/filters/mp4mx.c
+++ b/src/lib/filters/mp4mx.c
@@ -282,11 +282,13 @@ mp4mx_create_buffer_list(GF_Filter* filter)
       case INIT:
         if (!GET_TYPE(INIT)->is_complete)
           break;
+        GST_BUFFER_FLAG_SET(GET_TYPE(type)->buffer, GST_BUFFER_FLAG_HEADER);
+
         if (mp4mx_ctx->segment_count == 0) {
           GST_BUFFER_FLAG_SET(GET_TYPE(type)->buffer, GST_BUFFER_FLAG_DISCONT);
           ctx->is_continuous = TRUE;
         }
-        // fallthrough
+        break;
       case HEADER:
         GST_BUFFER_FLAG_SET(GET_TYPE(type)->buffer, GST_BUFFER_FLAG_HEADER);
 
@@ -322,7 +324,7 @@ mp4mx_create_buffer_list(GF_Filter* filter)
     GST_BUFFER_DTS(GET_TYPE(INIT)->buffer) =
       GST_BUFFER_DTS(GET_TYPE(HEADER)->buffer) -
       GST_BUFFER_DURATION(GET_TYPE(HEADER)->buffer);
-    GST_BUFFER_DURATION(GET_TYPE(INIT)->buffer) = 0;
+    GST_BUFFER_DURATION(GET_TYPE(INIT)->buffer) = GST_CLOCK_TIME_NONE;
   }
 
   // Copy the mdat header

--- a/tests/src/common.hpp
+++ b/tests/src/common.hpp
@@ -82,7 +82,7 @@ protected:
   void SetUp() override
   {
     source =
-      gst_element_factory_make_full("videotestsrc", "do-timestamp", TRUE, NULL);
+      gst_element_factory_make_full("videotestsrc", "do-timestamp", TRUE, "is-live", TRUE, NULL);
     GstElement* capsfilter = gst_element_factory_make_full(
       "capsfilter",
       "caps",

--- a/tests/src/common.hpp
+++ b/tests/src/common.hpp
@@ -31,7 +31,7 @@ public:
 
     // Set the appsink properties
     g_object_set(
-      appsink, "emit-signals", TRUE, "sync", FALSE, "buffer-list", TRUE, NULL);
+      appsink, "emit-signals", TRUE, "sync", TRUE, "buffer-list", TRUE, NULL);
 
     // Add the appsink to the test element
     gst_bin_add_many(GST_BIN(pipeline), queue, test_element, appsink, NULL);

--- a/tests/src/common.hpp
+++ b/tests/src/common.hpp
@@ -31,7 +31,7 @@ public:
 
     // Set the appsink properties
     g_object_set(
-      appsink, "emit-signals", TRUE, "sync", TRUE, "buffer-list", TRUE, NULL);
+      appsink, "emit-signals", TRUE, "sync", FALSE, "buffer-list", TRUE, NULL);
 
     // Add the appsink to the test element
     gst_bin_add_many(GST_BIN(pipeline), queue, test_element, appsink, NULL);
@@ -60,6 +60,8 @@ public:
   }
 
   ~GstAppSink() { gst_object_unref(appsink); }
+
+  void SetSync(bool sync) { g_object_set(appsink, "sync", sync, NULL); }
 };
 
 class GstTestFixture : public ::testing::Test
@@ -78,11 +80,12 @@ protected:
   static void TearDownTestSuite() { gst_deinit(); }
   GstElement* GetLastElement() { return last_element; }
   GstElement* GetEncoder() { return encoder; }
+  void SetLive(bool is_live) { g_object_set(source, "is-live", is_live, NULL); }
 
   void SetUp() override
   {
-    source =
-      gst_element_factory_make_full("videotestsrc", "do-timestamp", TRUE, "is-live", TRUE, NULL);
+    source = gst_element_factory_make_full(
+      "videotestsrc", "do-timestamp", TRUE, "is-live", FALSE, NULL);
     GstElement* capsfilter = gst_element_factory_make_full(
       "capsfilter",
       "caps",

--- a/tests/src/live.cc
+++ b/tests/src/live.cc
@@ -1,0 +1,24 @@
+#include "common.hpp"
+
+TEST_F(GstTestFixture, Live)
+{
+  this->SetUpPipeline({ false, "x264enc", 30 });
+  this->SetLive(true);
+
+  GstElement* gpacmp4mx =
+    gst_element_factory_make_full("gpacmp4mx", "cdur", 1.0, NULL);
+  GstAppSink* sink = new GstAppSink(gpacmp4mx, GetEncoder(), pipeline);
+  sink->SetSync(true);
+
+  this->StartPipeline();
+
+  // Count the number of buffers
+  int buffer_count = 0;
+  while (true) {
+    GstBufferList* buffer = sink->PopBuffer();
+    if (!buffer)
+      break;
+    buffer_count++;
+  }
+  EXPECT_EQ(buffer_count, 1);
+}

--- a/tests/src/mp4mx_cross.cc
+++ b/tests/src/mp4mx_cross.cc
@@ -40,6 +40,9 @@ IsSegmentInit(GstBuffer* buffer)
   EXPECT_TRUE(GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_HEADER));
   EXPECT_TRUE(GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DISCONT));
 
+  // This is not a delta unit
+  EXPECT_FALSE(GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT));
+
   // It must contain also contain at least "ftyp" and "moov" boxes
   std::vector<fourcc_t> fourccs;
   extract_box_fourccs(buffer, fourccs);


### PR DESCRIPTION
- Implement only the base class virtual methods
- Use pad segment to configure base GstAggregate src pad (simple solution for single sink pad use cases)
- Adds more detailed debug logging