### PR TITLE
Skip DURATION setting if the query fails

### DIFF
--- a/src/lib/conversion/pid/query_handlers.c
+++ b/src/lib/conversion/pid/query_handlers.c
@@ -61,8 +61,6 @@ QUERY_HANDLER_SIGNATURE(duration)
       return TRUE; // not an error, just skip setting duration
   }
   
-  gst_query_parse_duration(query, NULL, &duration);
-
   // Parse the duration
   gint64 duration;
   gst_query_parse_duration(query, NULL, &duration);

--- a/src/lib/conversion/pid/query_handlers.c
+++ b/src/lib/conversion/pid/query_handlers.c
@@ -56,10 +56,12 @@ QUERY_HANDLER_SIGNATURE(duration)
   g_autoptr(GstQuery) query = gst_query_new_duration(GST_FORMAT_TIME);
   gboolean ret = gst_pad_peer_query(priv->self, query);
   if (!ret) {
-    GST_ELEMENT_ERROR(
-      element, LIBRARY, FAILED, (NULL), ("Failed to query duration"));
-    return FALSE;
+      GST_WARNING("No segment event and duration query failed, "
+                  "skipping duration property (possibly live source)");
+      return TRUE; // not an error, just skip setting duration
   }
+  
+  gst_query_parse_duration(query, NULL, &duration);
 
   // Parse the duration
   gint64 duration;


### PR DESCRIPTION
Related to [this MR](https://github.com/gpac/gst-gpac-plugin/pull/15) 

We now return TRUE when the duration query fails, this is to prevent issues with the early return for the intersink and intersrc elements and avoiding setting an incorrect value